### PR TITLE
Update REPLICATE_API_TOKEN in env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,6 +1,6 @@
 # Copy to .env (do NOT commit .env)
 # Required for Replicate-based model calls
-REPLICATE_API_TOKEN=<REPLICATE_API_TOKEN>
+REPLICATE_API_TOKEN=r8_6LNGBpz0J5TgiFZ6GlxWa8wrbzGtHLm0wNV57
 
 # Optional (only if you enable ElevenLabs integration)
 ELEVENLABS_API_KEY=<ELEVENLABS_API_KEY>


### PR DESCRIPTION
### Motivation
- Provide a concrete Replicate token in the example env so Replicate-based model calls are easier to configure.

### Description
- Set `REPLICATE_API_TOKEN` in `env.example` to the provided API key; only `env.example` was modified and no runtime code paths were changed.

### Testing
- Verified the change with `git diff -- env.example`, `git status --short`, and created a commit which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c855a2953083269d08eaff9ae0a229)

## Summary by Sourcery

No effective changes were made, as the diff shows env.example remains unchanged.